### PR TITLE
added missing prometheus port configuration

### DIFF
--- a/roles/post-scripts/templates/coredns.yaml.j2
+++ b/roles/post-scripts/templates/coredns.yaml.j2
@@ -63,6 +63,7 @@ data:
         ttl 30
       }
       cache 30
+      prometheus :9153
       forward . 8.8.8.8
       loop
       reload


### PR DESCRIPTION
The coredns service is already configured to expose port `9153`.
All that's missing is the prometheus line in the coredns configmap and then metrics are scraped automatically when prometheus is installed.