### PR TITLE
Make ILKE taints standard

### DIFF
--- a/roles/post-scripts/tasks/label-hosts.yaml
+++ b/roles/post-scripts/tasks/label-hosts.yaml
@@ -30,7 +30,7 @@
 - name: Make hosts with master role not NoSchedulabe (if not a worker or storage)
   command: |
     kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
-    taint nodes {{ item }} node-role.kubernetes.io/master:NoSchedule --overwrite
+    taint nodes {{ item }} node-role.kubernetes.io/master=true:NoSchedule --overwrite
   changed_when: false
   with_items:
   - "{{ groups['masters'] }}"
@@ -41,20 +41,18 @@
 - name: Make hosts with Storage role not NoSchedulabe (if not a worker, but can be a master)
   command: |
     kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
-    taint nodes {{ item }} node-role.kubernetes.io/storage:NoSchedule --overwrite
+    taint nodes {{ item }} node-role.kubernetes.io/storage=true:NoSchedule --overwrite
   changed_when: false
   with_items:
   - "{{ groups['storage'] }}"
   when:
     - item not in groups['workers']
 
-#- name: Make sure hosts with worker role Schedulabe
-#  command: |
-#    kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
-#    taint nodes {{ item }} NoSchedulabe=true:NoSchedule- --overwrite
-#  changed_when: false
-#  with_items:
-#  - "{{ groups['masters'] }}"
-#  - "{{ groups['storage'] }}"
-#  when: item in groups['workers']
-#  ignore_errors: yes
+- name: Make sure hosts with worker role Schedulabe
+  command: |
+    kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
+    taint nodes {{ item }} true:NoSchedule- --overwrite
+  changed_when: false
+  with_items:
+  - "{{ groups['workers'] }}"
+  ignore_errors: yes

--- a/roles/post-scripts/tasks/label-hosts.yaml
+++ b/roles/post-scripts/tasks/label-hosts.yaml
@@ -35,6 +35,7 @@
     - "{{ groups['storage'] }}"
   when:
     - item not in groups['workers']
+  ignore_errors: yes
 
 - name: remove label node-role.kubernetes.io/master=true
   command: "kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf label node {{ item }}  node-role.kubernetes.io/master=true- --overwrite"
@@ -44,6 +45,7 @@
     - "{{ groups['storage'] }}"
   when:
     - item not in groups['masters']
+  ignore_errors: yes
 
 - name: remove label node-role.kubernetes.io/storage=true
   command: "kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf label node {{ item }}  node-role.kubernetes.io/storage=true- --overwrite"
@@ -53,6 +55,7 @@
     - "{{ groups['masters'] }}"
   when:
     - item not in groups['storages']
+  ignore_errors: yes
 
 - name: Make hosts with master role not NoSchedulabe (if not a worker or storage)
   command: |

--- a/roles/post-scripts/tasks/label-hosts.yaml
+++ b/roles/post-scripts/tasks/label-hosts.yaml
@@ -27,6 +27,33 @@
   changed_when: false
   with_items: "{{ groups['masters'] }}"
 
+- name: remove label node-role.kubernetes.io/worker=true
+  command: "kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf label node {{ item }}  node-role.kubernetes.io/worker=true- --overwrite"
+  changed_when: false
+  with_items:
+    - "{{ groups['masters'] }}"
+    - "{{ groups['storage'] }}"
+  when:
+    - item not in groups['workers']
+
+- name: remove label node-role.kubernetes.io/master=true
+  command: "kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf label node {{ item }}  node-role.kubernetes.io/master=true- --overwrite"
+  changed_when: false
+  with_items:
+    - "{{ groups['workers'] }}"
+    - "{{ groups['storage'] }}"
+  when:
+    - item not in groups['masters']
+
+- name: remove label node-role.kubernetes.io/storage=true
+  command: "kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf label node {{ item }}  node-role.kubernetes.io/storage=true- --overwrite"
+  changed_when: false
+  with_items:
+    - "{{ groups['workers'] }}"
+    - "{{ groups['masters'] }}"
+  when:
+    - item not in groups['storages']
+
 - name: Make hosts with master role not NoSchedulabe (if not a worker or storage)
   command: |
     kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
@@ -51,7 +78,7 @@
 - name: Make sure hosts with worker role not have taint node-role.kubernetes.io/storage
   command: |
     kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
-    taint nodes {{ item }} node-role.kubernetes.io/storage-
+    taint nodes {{ item }} node-role.kubernetes.io/storage- --overwrite
   changed_when: false
   with_items:
   - "{{ groups['workers'] }}"
@@ -60,7 +87,7 @@
 - name: Make sure hosts with worker role not have taint node-role.kubernetes.io/master
   command: |
     kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
-    taint nodes {{ item }} node-role.kubernetes.io/master-
+    taint nodes {{ item }} node-role.kubernetes.io/master- --overwrite
   changed_when: false
   with_items:
   - "{{ groups['workers'] }}"

--- a/roles/post-scripts/tasks/label-hosts.yaml
+++ b/roles/post-scripts/tasks/label-hosts.yaml
@@ -54,7 +54,7 @@
     - "{{ groups['workers'] }}"
     - "{{ groups['masters'] }}"
   when:
-    - item not in groups['storages']
+    - item not in groups['storage']
   ignore_errors: yes
 
 - name: Make hosts with master role not NoSchedulabe (if not a worker or storage)

--- a/roles/post-scripts/tasks/label-hosts.yaml
+++ b/roles/post-scripts/tasks/label-hosts.yaml
@@ -48,10 +48,19 @@
   when:
     - item not in groups['workers']
 
-- name: Make sure hosts with worker role Schedulabe
+- name: Make sure hosts with worker role not have taint node-role.kubernetes.io/storage
   command: |
     kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
-    taint nodes {{ item }} true:NoSchedule- --overwrite
+    taint nodes {{ item }} node-role.kubernetes.io/storage-
+  changed_when: false
+  with_items:
+  - "{{ groups['workers'] }}"
+  ignore_errors: yes
+
+- name: Make sure hosts with worker role not have taint node-role.kubernetes.io/master
+  command: |
+    kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
+    taint nodes {{ item }} node-role.kubernetes.io/master-
   changed_when: false
   with_items:
   - "{{ groups['workers'] }}"

--- a/roles/post-scripts/tasks/label-hosts.yaml
+++ b/roles/post-scripts/tasks/label-hosts.yaml
@@ -10,6 +10,7 @@
   with_items:
     - "{{ groups['masters'] }}"
     - "{{ groups['workers'] }}"
+    - "{{ groups['storage'] }}"
 
 - name: Label Woker Nodes
   command: "kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf label node {{ item }}  node-role.kubernetes.io/worker=true --overwrite"
@@ -26,24 +27,34 @@
   changed_when: false
   with_items: "{{ groups['masters'] }}"
 
-- name: Make hosts with master or storage role NoSchedulabe (if not a worker)
+- name: Make hosts with master role not NoSchedulabe (if not a worker or storage)
   command: |
     kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
-    taint nodes {{ item }} NoSchedulabe=true:NoSchedule --overwrite
+    taint nodes {{ item }} node-role.kubernetes.io/master:NoSchedule --overwrite
   changed_when: false
   with_items:
   - "{{ groups['masters'] }}"
+  when:
+    - item not in groups['workers']
+    - item not in groups['storage']
+
+- name: Make hosts with Storage role not NoSchedulabe (if not a worker, but can be a master)
+  command: |
+    kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
+    taint nodes {{ item }} node-role.kubernetes.io/storage:NoSchedule --overwrite
+  changed_when: false
+  with_items:
   - "{{ groups['storage'] }}"
   when:
     - item not in groups['workers']
 
-- name: Make sure hosts with worker role Schedulabe
-  command: |
-    kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
-    taint nodes {{ item }} NoSchedulabe=true:NoSchedule- --overwrite
-  changed_when: false
-  with_items:
-  - "{{ groups['masters'] }}"
-  - "{{ groups['storage'] }}"
-  when: item in groups['workers']
-  ignore_errors: yes
+#- name: Make sure hosts with worker role Schedulabe
+#  command: |
+#    kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf \
+#    taint nodes {{ item }} NoSchedulabe=true:NoSchedule- --overwrite
+#  changed_when: false
+#  with_items:
+#  - "{{ groups['masters'] }}"
+#  - "{{ groups['storage'] }}"
+#  when: item in groups['workers']
+#  ignore_errors: yes

--- a/roles/post-scripts/templates/Readme.md
+++ b/roles/post-scripts/templates/Readme.md
@@ -72,10 +72,9 @@ Add to all Deployments, DaemonSet
 
 ```
 tolerations:
-    - key: "NoSchedulabe"
-      operator: "Exists"
-      effect: "NoSchedule"
-nodeSelector:
+      - effect: NoSchedule
+        operator: Exists
+      nodeSelector:
         "node-role.kubernetes.io/storage": "true"
 ```
 

--- a/roles/post-scripts/templates/openebs.yaml.j2
+++ b/roles/post-scripts/templates/openebs.yaml.j2
@@ -103,9 +103,8 @@ spec:
         openebs.io/version: {{ ilke_features.storage.release }}
     spec:
       tolerations:
-      - key: "NoSchedulabe"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - effect: NoSchedule
+        operator: Exists
       nodeSelector:
         "node-role.kubernetes.io/storage": "true"
       serviceAccountName: openebs-maya-operator
@@ -280,9 +279,8 @@ spec:
         openebs.io/version: {{ ilke_features.storage.release }}
     spec:
       tolerations:
-      - key: "NoSchedulabe"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - effect: NoSchedule
+        operator: Exists
       nodeSelector:
         "node-role.kubernetes.io/storage": "true"
       serviceAccountName: openebs-maya-operator
@@ -359,9 +357,8 @@ spec:
         openebs.io/version: {{ ilke_features.storage.release }}
     spec:
       tolerations:
-      - key: "NoSchedulabe"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - effect: NoSchedule
+        operator: Exists
       nodeSelector:
         "node-role.kubernetes.io/storage": "true"
       serviceAccountName: openebs-maya-operator
@@ -491,9 +488,8 @@ spec:
         openebs.io/version: {{ ilke_features.storage.release }}
     spec:
       tolerations:
-      - key: "NoSchedulabe"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - effect: NoSchedule
+        operator: Exists
       nodeSelector:
         "node-role.kubernetes.io/storage": "true"
       # By default the node-disk-manager will be run on all kubernetes nodes
@@ -621,9 +617,8 @@ spec:
         openebs.io/version: {{ ilke_features.storage.release }}
     spec:
       tolerations:
-      - key: "NoSchedulabe"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - effect: NoSchedule
+        operator: Exists
       nodeSelector:
         "node-role.kubernetes.io/storage": "true"
       serviceAccountName: openebs-maya-operator
@@ -697,9 +692,8 @@ spec:
         openebs.io/version: {{ ilke_features.storage.release }}
     spec:
       tolerations:
-      - key: "NoSchedulabe"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - effect: NoSchedule
+        operator: Exists
       nodeSelector:
         "node-role.kubernetes.io/storage": "true"
       serviceAccountName: openebs-maya-operator
@@ -760,9 +754,8 @@ spec:
         openebs.io/version: {{ ilke_features.storage.release }}
     spec:
       tolerations:
-      - key: "NoSchedulabe"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - effect: NoSchedule
+        operator: Exists
       nodeSelector:
         "node-role.kubernetes.io/storage": "true"
       serviceAccountName: openebs-maya-operator


### PR DESCRIPTION
This PR fix #38 

This is a major update of ILKE taint/labels policy.

**ONLY Masters** will have taint : **node-role.kubernetes.io/master=true:NoSchedule**
**(Master AND Storage), or ONLY Storage** will have taint: **node-role.kubernetes.io/storage=true:NoSchedule**
**Worker** will not have taint and will be fully schedulable.

Taints and labels support to be updated and follow the inventory "hosts" ILKE file