### PR TITLE
use actual coredns replica value

### DIFF
--- a/roles/post-scripts/tasks/coredns.yaml
+++ b/roles/post-scripts/tasks/coredns.yaml
@@ -29,7 +29,7 @@
   command: kubectl --kubeconfig {{ pki_path }}/kubeconfigs/admin/admin.conf get deploy -n kube-system coredns
   changed_when: false
   register: dashboard_deployment
-  until: dashboard_deployment.stdout.find("2/2") != -1
+  until: dashboard_deployment.stdout.find(ilke_features.coredns.replicas | string + "/" + ilke_features.coredns.replicas | string) != -1
   retries: 300
   delay: 10
   run_once: true


### PR DESCRIPTION
This removes the hardcoded coredns pod value and uses the value set in group_vars